### PR TITLE
Use the official postgis image.

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,6 +4,6 @@ docker_run="docker run"
 docker_run="$docker_run -e POSTGRES_DB=$INPUT_POSTGRESQL_DB"
 docker_run="$docker_run -e POSTGRES_USER=$INPUT_POSTGRESQL_USER"
 docker_run="$docker_run -e POSTGRES_PASSWORD=$INPUT_POSTGRESQL_PASSWORD"
-docker_run="$docker_run -d -p 5432:5432 mdillon/postgis:$INPUT_POSTGRESQL_VERSION"
+docker_run="$docker_run -d -p 5432:5432 postgis/postgis:$INPUT_POSTGRESQL_VERSION"
 
 sh -c "$docker_run"


### PR DESCRIPTION
The [mdillon/postgis](https://hub.docker.com/r/mdillon/postgis/tags) image does not support versions 10 and up. For this reason, workflows fail if we use any version other than 9. The official [postgis/postgis](https://hub.docker.com/r/postgis/postgis/tags) image has more supported versions.